### PR TITLE
Fix to use Java 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'com.basicbug'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = '8'
 
 configurations {
 	compileOnly {


### PR DESCRIPTION
- heroku is only support JDK8

Signed-off-by: qwebnm7788 <qwebnm7788@naver.com>