### PR TITLE
Add code and message for /login/naver success response

### DIFF
--- a/src/main/java/com/basicbug/bikini/controller/AuthController.java
+++ b/src/main/java/com/basicbug/bikini/controller/AuthController.java
@@ -56,7 +56,7 @@ public class AuthController {
             AuthError error = AuthError.INVALID_PARAM;
             return CommonResponse.error(error.errorCode, error.errorMsg);
         } else {
-            return CommonResponse.of(jwtToken);
+            return CommonResponse.of(jwtToken, "200", "Success");
         }
     }
 

--- a/src/main/java/com/basicbug/bikini/dto/common/CommonResponse.java
+++ b/src/main/java/com/basicbug/bikini/dto/common/CommonResponse.java
@@ -35,8 +35,7 @@ public class CommonResponse<T> {
         return new CommonResponse<>(result, code, null);
     }
 
-    public static <T> CommonResponse<T> of(final T result, final String code,
-        final String message) {
+    public static <T> CommonResponse<T> of(final T result, final String code, final String message) {
         return new CommonResponse<>(result, code, message);
     }
 }


### PR DESCRIPTION
- TODO
  * Refactoring code and message as Constants
  * Use default response value for CommonResponse objects

Signed-off-by: qwebnm7788 <qwebnm7788@naver.com>