### PR TITLE
[FEAT] Swagger endpoint 분리

### DIFF
--- a/src/main/java/com/basicbug/bikini/config/swagger/SwaggerConfiguration.java
+++ b/src/main/java/com/basicbug/bikini/config/swagger/SwaggerConfiguration.java
@@ -1,5 +1,10 @@
 package com.basicbug.bikini.config.swagger;
 
+import static com.basicbug.bikini.config.swagger.SwaggerConstants.AUTH;
+import static com.basicbug.bikini.config.swagger.SwaggerConstants.COMMON;
+import static com.basicbug.bikini.config.swagger.SwaggerConstants.FEED;
+import static com.basicbug.bikini.config.swagger.SwaggerConstants.VERSION_1;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
@@ -14,22 +19,41 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableSwagger2
 public class SwaggerConfiguration {
 
+    private static final String CONTROLLER_BASE_PATH = "com.basicbug.bikini.controller";
+    private static final String GROUP_URL_PATTERN = "/%s/%s/**";
+
     @Bean
-    public Docket swaggerApi() {
-        return new Docket(DocumentationType.SWAGGER_2)
-            .apiInfo(apiInfo())
-            .select()
-            .apis(RequestHandlerSelectors.basePackage("com.basicbug.bikini.controller"))
-            .paths(PathSelectors.any())
-            .build();
+    public Docket feedApiDocket() {
+        return createDocket(FEED, String.format(GROUP_URL_PATTERN, VERSION_1, FEED), VERSION_1);
     }
 
-    private ApiInfo apiInfo() {
+    @Bean
+    public Docket authApiDocket() {
+        return createDocket(AUTH, String.format(GROUP_URL_PATTERN, VERSION_1, AUTH), VERSION_1);
+    }
+
+    @Bean
+    public Docket commonApiDocket() {
+        return createDocket(COMMON, String.format(GROUP_URL_PATTERN, VERSION_1, COMMON), VERSION_1);
+    }
+
+    private Docket createDocket(String groupName, String groupUrl, String version) {
+        return new Docket(DocumentationType.SWAGGER_2)
+            .useDefaultResponseMessages(false)
+            .groupName(groupName)
+            .select()
+            .apis(RequestHandlerSelectors.basePackage(CONTROLLER_BASE_PATH))
+            .paths(PathSelectors.ant(groupUrl))
+            .build()
+            .apiInfo(apiInfo(groupName + "-" + version, version));
+    }
+
+    private ApiInfo apiInfo(String title, String version) {
         return new ApiInfoBuilder()
-            .title("BasicBug API Documentation")
+            .title(title)
             .description("BasicBug Bikini API Docs")
             .license("BasicBug")
-            .version("1")
+            .version(version)
             .build();
     }
 }

--- a/src/main/java/com/basicbug/bikini/config/swagger/SwaggerConstants.java
+++ b/src/main/java/com/basicbug/bikini/config/swagger/SwaggerConstants.java
@@ -1,0 +1,10 @@
+package com.basicbug.bikini.config.swagger;
+
+public class SwaggerConstants {
+
+    public static final String COMMON = "common";
+    public static final String FEED = "feed";
+    public static final String AUTH = "auth";
+
+    public static final String VERSION_1 = "v1";
+}

--- a/src/main/java/com/basicbug/bikini/controller/auth/AuthController.java
+++ b/src/main/java/com/basicbug/bikini/controller/auth/AuthController.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.ModelAndView;
+import springfox.documentation.annotations.ApiIgnore;
 
 @Slf4j
 @RestController
@@ -59,6 +60,7 @@ public class AuthController {
         }
     }
 
+    @ApiIgnore
     @GetMapping("/test/login")
     public ModelAndView testLoginPage(ModelAndView modelAndView) {
         String naverRedirect = "http://localhost:8080/v1/auth/redirect/naver";
@@ -82,6 +84,7 @@ public class AuthController {
         return loginUrl.toString();
     }
 
+    @ApiIgnore
     @GetMapping("/redirect/{provider}")
     public ModelAndView redirectNaverLogin(ModelAndView modelAndView, @RequestParam String code, @PathVariable String provider) {
         HttpHeaders httpHeaders = new HttpHeaders();

--- a/src/main/java/com/basicbug/bikini/controller/auth/AuthController.java
+++ b/src/main/java/com/basicbug/bikini/controller/auth/AuthController.java
@@ -1,4 +1,4 @@
-package com.basicbug.bikini.controller;
+package com.basicbug.bikini.controller.auth;
 
 import com.basicbug.bikini.config.auth.AuthConfig;
 import com.basicbug.bikini.config.auth.KakaoAuthConfig;

--- a/src/main/java/com/basicbug/bikini/controller/common/HealthController.java
+++ b/src/main/java/com/basicbug/bikini/controller/common/HealthController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/v1/health")
+@RequestMapping("/v1/common")
 @RequiredArgsConstructor
 public class HealthController {
 

--- a/src/main/java/com/basicbug/bikini/controller/common/HealthController.java
+++ b/src/main/java/com/basicbug/bikini/controller/common/HealthController.java
@@ -1,4 +1,4 @@
-package com.basicbug.bikini.controller;
+package com.basicbug.bikini.controller.common;
 
 import com.basicbug.bikini.dto.common.CommonResponse;
 import io.swagger.annotations.ApiOperation;

--- a/src/main/java/com/basicbug/bikini/controller/feed/FeedController.java
+++ b/src/main/java/com/basicbug/bikini/controller/feed/FeedController.java
@@ -1,4 +1,4 @@
-package com.basicbug.bikini.controller;
+package com.basicbug.bikini.controller.feed;
 
 
 import com.basicbug.bikini.dto.common.CommonResponse;
@@ -8,7 +8,6 @@ import com.basicbug.bikini.dto.feed.FeedImageResponseDto;
 import com.basicbug.bikini.dto.feed.FeedListResponse;
 import com.basicbug.bikini.dto.feed.FeedNearLocationRequestDto;
 import com.basicbug.bikini.dto.feed.FeedUpdateRequestDto;
-import com.basicbug.bikini.model.FeedImage;
 import com.basicbug.bikini.service.FeedService;
 import io.swagger.annotations.ApiOperation;
 import java.util.List;


### PR DESCRIPTION
Related issues: #63

-Swagger 의 API docs 를 endpoint 별로 볼 수 있도록 분리
- /v1/health 를 /v1/common 으로 수정
- /v1/auth 에서 개발용으로 사용되는 API는 Swagger 에서 보이지 않도록 수정