### PR TITLE
[Refactoring] Change to use AuthProvider instead of String

### DIFF
--- a/src/main/java/com/basicbug/bikini/controller/GlobalRestControllerAdvice.java
+++ b/src/main/java/com/basicbug/bikini/controller/GlobalRestControllerAdvice.java
@@ -1,0 +1,31 @@
+package com.basicbug.bikini.controller;
+
+import com.basicbug.bikini.dto.common.CommonResponse;
+import com.basicbug.bikini.model.auth.AuthError;
+import com.basicbug.bikini.model.auth.exception.InvalidAccessTokenException;
+import com.basicbug.bikini.model.auth.exception.InvalidProviderException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(annotations = RestController.class)
+public class GlobalRestControllerAdvice {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({InvalidProviderException.class})
+    public CommonResponse<String> handleBadParameter(Exception exception) {
+        log.info("Bad parameter request : ", exception);
+        return CommonResponse.error(AuthError.INVALID_PROVIDER.errorCode, AuthError.INVALID_PROVIDER.errorMsg);
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({InvalidAccessTokenException.class})
+    public CommonResponse<String> handleInvalidAccessToken(Exception exception) {
+        log.info("Invalid access token request : ", exception);
+        return CommonResponse.error(AuthError.INVALID_ACCESS_TOKEN.errorCode, AuthError.INVALID_ACCESS_TOKEN.errorMsg);
+    }
+}

--- a/src/main/java/com/basicbug/bikini/controller/auth/AuthController.java
+++ b/src/main/java/com/basicbug/bikini/controller/auth/AuthController.java
@@ -51,13 +51,7 @@ public class AuthController {
     public CommonResponse<String> login(@PathVariable("provider") String provider, AuthRequestDto requestDto) {
         AuthProvider authProvider = AuthProvider.of(provider.toUpperCase());
         String jwtToken = userService.loadUserInfo(requestDto, authProvider);
-
-        if (jwtToken.isEmpty()) {
-            AuthError error = AuthError.INVALID_ACCESS_TOKEN;
-            return CommonResponse.error(error.errorCode, error.errorMsg);
-        } else {
-            return CommonResponse.of(jwtToken, "200", "Success");
-        }
+        return CommonResponse.of(jwtToken, HttpStatus.OK.value(), "Success");
     }
 
     @ApiIgnore
@@ -126,20 +120,6 @@ public class AuthController {
             return kakaoAuthConfig;
         } else {
             return naverAuthConfig;
-        }
-    }
-
-    enum AuthError {
-
-        INVALID_PROVIDER("1000", "Invalid provider"),
-        INVALID_ACCESS_TOKEN("2000", "Invalid access token");
-
-        String errorCode;
-        String errorMsg;
-
-        AuthError(String errorCode, String errorMsg) {
-            this.errorCode = errorCode;
-            this.errorMsg = errorMsg;
         }
     }
 }

--- a/src/main/java/com/basicbug/bikini/controller/auth/AuthController.java
+++ b/src/main/java/com/basicbug/bikini/controller/auth/AuthController.java
@@ -49,13 +49,8 @@ public class AuthController {
     @GetMapping("/login/{provider}")
     @ResponseStatus(HttpStatus.OK)
     public CommonResponse<String> login(@PathVariable("provider") String provider, AuthRequestDto requestDto) {
-        // TODO: provider validation
-        if (!provider.equals(AuthProvider.KAKAO.getName()) && !provider.equals(AuthProvider.NAVER.getName())) {
-            AuthError error = AuthError.INVALID_PROVIDER;
-            return CommonResponse.error(error.errorCode, error.errorMsg);
-        }
-
-        String jwtToken = userService.loadUserInfo(requestDto, provider);
+        AuthProvider authProvider = AuthProvider.of(provider.toUpperCase());
+        String jwtToken = userService.loadUserInfo(requestDto, authProvider);
 
         if (jwtToken.isEmpty()) {
             AuthError error = AuthError.INVALID_ACCESS_TOKEN;

--- a/src/main/java/com/basicbug/bikini/dto/common/CommonResponse.java
+++ b/src/main/java/com/basicbug/bikini/dto/common/CommonResponse.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 public class CommonResponse<T> {
 
     private T result;
-    private String code;
+    private Integer code;
     private String message;
 
-    public CommonResponse(final T result, final String code, final String message) {
+    public CommonResponse(final T result, final Integer code, final String message) {
         this.result = result;
         this.code = code;
         this.message = message;
@@ -19,11 +19,11 @@ public class CommonResponse<T> {
         return new CommonResponse<>(null, null, null);
     }
 
-    public static <Void> CommonResponse<Void> error(final String code) {
+    public static <Void> CommonResponse<Void> error(final Integer code) {
         return new CommonResponse<>(null, code, null);
     }
 
-    public static <Void> CommonResponse<Void> error(final String code, final String message) {
+    public static <Void> CommonResponse<Void> error(final Integer code, final String message) {
         return new CommonResponse<>(null, code, message);
     }
 
@@ -31,11 +31,11 @@ public class CommonResponse<T> {
         return new CommonResponse<>(result, null, null);
     }
 
-    public static <T> CommonResponse<T> of(final T result, final String code) {
+    public static <T> CommonResponse<T> of(final T result, final Integer code) {
         return new CommonResponse<>(result, code, null);
     }
 
-    public static <T> CommonResponse<T> of(final T result, final String code, final String message) {
+    public static <T> CommonResponse<T> of(final T result, final Integer code, final String message) {
         return new CommonResponse<>(result, code, message);
     }
 }

--- a/src/main/java/com/basicbug/bikini/model/auth/AuthError.java
+++ b/src/main/java/com/basicbug/bikini/model/auth/AuthError.java
@@ -1,0 +1,15 @@
+package com.basicbug.bikini.model.auth;
+
+public enum AuthError {
+
+    INVALID_PROVIDER(1000, "Invalid provider"),
+    INVALID_ACCESS_TOKEN(2000, "Invalid access token");
+
+    public final int errorCode;
+    public final String errorMsg;
+
+    AuthError(int errorCode, String errorMsg) {
+        this.errorCode = errorCode;
+        this.errorMsg = errorMsg;
+    }
+}

--- a/src/main/java/com/basicbug/bikini/model/auth/AuthProvider.java
+++ b/src/main/java/com/basicbug/bikini/model/auth/AuthProvider.java
@@ -1,5 +1,7 @@
 package com.basicbug.bikini.model.auth;
 
+import java.util.Arrays;
+
 public enum AuthProvider {
     NAVER("naver"),
     KAKAO("kakao");
@@ -12,5 +14,12 @@ public enum AuthProvider {
 
     public String getName() {
         return this.name;
+    }
+
+    public static AuthProvider of(String provider) {
+        return Arrays.stream(AuthProvider.values())
+            .filter(authProvider -> authProvider.name.equalsIgnoreCase(provider))
+            .findAny()
+            .orElseThrow(() -> new IllegalArgumentException("해당하는 provider 가 없습니다."));
     }
 }

--- a/src/main/java/com/basicbug/bikini/model/auth/AuthProvider.java
+++ b/src/main/java/com/basicbug/bikini/model/auth/AuthProvider.java
@@ -1,5 +1,6 @@
 package com.basicbug.bikini.model.auth;
 
+import com.basicbug.bikini.model.auth.exception.InvalidProviderException;
 import java.util.Arrays;
 
 public enum AuthProvider {
@@ -20,6 +21,6 @@ public enum AuthProvider {
         return Arrays.stream(AuthProvider.values())
             .filter(authProvider -> authProvider.name.equalsIgnoreCase(provider))
             .findAny()
-            .orElseThrow(() -> new IllegalArgumentException("해당하는 provider 가 없습니다."));
+            .orElseThrow(() -> new InvalidProviderException("해당하는 provider 가 없습니다."));
     }
 }

--- a/src/main/java/com/basicbug/bikini/model/auth/exception/InvalidAccessTokenException.java
+++ b/src/main/java/com/basicbug/bikini/model/auth/exception/InvalidAccessTokenException.java
@@ -1,0 +1,7 @@
+package com.basicbug.bikini.model.auth.exception;
+
+public class InvalidAccessTokenException extends IllegalArgumentException {
+    public InvalidAccessTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/basicbug/bikini/model/auth/exception/InvalidProviderException.java
+++ b/src/main/java/com/basicbug/bikini/model/auth/exception/InvalidProviderException.java
@@ -1,0 +1,7 @@
+package com.basicbug.bikini.model.auth.exception;
+
+public class InvalidProviderException extends IllegalArgumentException {
+    public InvalidProviderException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/basicbug/bikini/service/UserService.java
+++ b/src/main/java/com/basicbug/bikini/service/UserService.java
@@ -7,6 +7,7 @@ import com.basicbug.bikini.model.AuthConstants;
 import com.basicbug.bikini.model.CommonConstants;
 import com.basicbug.bikini.model.User;
 import com.basicbug.bikini.model.UserPrincipal;
+import com.basicbug.bikini.model.auth.AuthProvider;
 import com.basicbug.bikini.model.auth.NaverProfile;
 import com.basicbug.bikini.model.auth.exception.OAuthProcessException;
 import com.basicbug.bikini.repository.UserRepository;
@@ -30,13 +31,13 @@ public class UserService {
     private final WebClient webClient = WebClient.builder().build();
 
     // TODO: Refactor to more generic way
-    public String loadUserInfo(AuthRequestDto authRequestDto, String provider) {
+    public String loadUserInfo(AuthRequestDto authRequestDto, AuthProvider provider) {
         String accessToken = authRequestDto.getAccessToken();
 
         if (accessToken.isEmpty()) return "";
 
         String profileUrl = "";
-        if (provider.equals("kakao")) {
+        if (provider == AuthProvider.KAKAO) {
             profileUrl = "https://kapi.kakao.com/v2/user/me";
         } else {
             profileUrl = "https://openapi.naver.com/v1/nid/me";
@@ -52,11 +53,11 @@ public class UserService {
         return requestProfileAndGetJwtToken(provider, spec);
     }
 
-    private String requestProfileAndGetJwtToken(String provider, WebClient.ResponseSpec spec) {
+    private String requestProfileAndGetJwtToken(AuthProvider provider, WebClient.ResponseSpec spec) {
         String email = "";
 
         try {
-            if (provider.equals("kakao")) {
+            if (provider == AuthProvider.KAKAO) {
                 KakaoProfileResponseDto response = spec.bodyToMono(KakaoProfileResponseDto.class).block();
                 if (response != null) {
                     Long id = response.getId();


### PR DESCRIPTION
String 으로 전달받은 provider 정보를 enum type 으로 변환하여 사용하도록 수정

Converter 를 사용하여 Controller 에서 전달받을 때 곧바로 적용할 수도 있지만, 모든 enum type 에 대해서
컨버터를 생성해주어야 하는 것 같아보여, 전달받은 파라미터를 대문자로 비교하여 사용.

Signed-off-by: qwebnm7788 <qwebnm7788@naver.com>