### PR TITLE
Prod 환경에서 data.sql 을 사용한 초기화 사용 제거

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -5,7 +5,7 @@ spring:
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
     sql-script-encoding: UTF-8
-    initialization-mode: always
+    initialization-mode: never
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect


### PR DESCRIPTION
#84 수정 사항

- spring.datasource.initialization-mode=never 로 설정하여
  prod 환경에서는 스크립트를 사용한 초기화 스크립트를 사용하지 않도록
  수정

Signed-off-by: qwebnm7788 <qwebnm7788@naver.com>