### PR TITLE
feat: JwtAuthenticationEntryPoint 구현 추가

### DIFF
--- a/src/main/java/com/basicbug/bikini/auth/filter/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/basicbug/bikini/auth/filter/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.basicbug.bikini.auth.filter;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse,
+        AuthenticationException e) throws IOException, ServletException {
+
+        log.error("UnAuthorized requests");
+
+        httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, "UnAuthorized");
+    }
+}

--- a/src/main/java/com/basicbug/bikini/auth/util/JwtTokenProvider.java
+++ b/src/main/java/com/basicbug/bikini/auth/util/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.basicbug.bikini.auth.util;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTDecodeException;
 import java.util.Date;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +48,11 @@ public class JwtTokenProvider {
     }
 
     public boolean isTokenExpired(String token) {
-        return JWT.decode(token).getExpiresAt().before(new Date());
+        try {
+            return JWT.decode(token).getExpiresAt().before(new Date());
+        } catch (JWTDecodeException exception) {
+            return true;
+        }
     }
 
     public long getExpireTime(String token) {

--- a/src/main/java/com/basicbug/bikini/config/security/WebSecurityConfig.java
+++ b/src/main/java/com/basicbug/bikini/config/security/WebSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.basicbug.bikini.config.security;
 
+import com.basicbug.bikini.auth.filter.JwtAuthenticationEntryPoint;
 import com.basicbug.bikini.auth.filter.JwtAuthorizationFilter;
 import com.basicbug.bikini.auth.util.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 @EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -39,6 +42,9 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             .antMatchers("/v1/auth/**").permitAll()
             .antMatchers("/v1/feed/**").permitAll()
             .anyRequest().authenticated()
+            .and()
+            .exceptionHandling()
+            .authenticationEntryPoint(jwtAuthenticationEntryPoint)
             .and()
             .headers().frameOptions().disable()
             .and()


### PR DESCRIPTION
## 변경사항
- 인증 실패시 항상 401 응답을 반환하기 위해 추가함

## 추가 구현 필요한 사항
- 권한이 적합하지 않은 경우엔 403 응답을 반환하도록 처리 필요