### PR TITLE
[PR] fix: Refresh token 타입의 column 명을 tokenId 로 변경

### DIFF
--- a/src/main/java/com/basicbug/bikini/auth/model/RefreshToken.java
+++ b/src/main/java/com/basicbug/bikini/auth/model/RefreshToken.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 public class RefreshToken extends BaseEntity {
 
     @Id
-    String key;
+    String tokenId;
 
     String token;
 

--- a/src/main/java/com/basicbug/bikini/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/basicbug/bikini/auth/repository/RefreshTokenRepository.java
@@ -7,5 +7,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
-    Optional<RefreshToken> findByKey(String key);
+    Optional<RefreshToken> findByTokenId(String tokenId);
 }

--- a/src/main/java/com/basicbug/bikini/user/service/UserService.java
+++ b/src/main/java/com/basicbug/bikini/user/service/UserService.java
@@ -99,7 +99,7 @@ public class UserService {
         }
 
         Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-        RefreshToken savedRefreshToken = refreshTokenRepository.findByKey(authentication.getName())
+        RefreshToken savedRefreshToken = refreshTokenRepository.findByTokenId(authentication.getName())
             .orElseThrow(() -> new RefreshTokenNotFoundException("token is not exists"));
 
         if (!savedRefreshToken.getToken().equals(refreshToken)) {
@@ -133,7 +133,7 @@ public class UserService {
             .refreshToken(jwtTokenProvider.createRefreshToken(user.getUid(), user.getRoles()))
             .build();
 
-        RefreshToken refreshToken = RefreshToken.builder().key(user.getUid())
+        RefreshToken refreshToken = RefreshToken.builder().tokenId(user.getUid())
             .token(oAuthToken.getRefreshToken())
             .expireTime(jwtTokenProvider.getExpireTime(oAuthToken.getRefreshToken()))
             .build();


### PR DESCRIPTION
- Refresh Token 의 Primary Key 의 이름을 "key" 로 하니 실제 JPA를 통해 쿼리가 발생할 때
   별도의 처리를 수행하지 않아 Maria DB 에 쿼리가 정상적으로 동작하지 않음.
   
   (local/heroku 의 경우는 H2 DB 를 사용해서 발생하지 않은듯..?)

- 수정 방법에는 다음과 같은 것이 있음

1. 해당 Column 에 대해 직접 double quote 로 escape 해준다.
`@Column(name = "\"key\"")`

2. 자동으로 전체 필드에 대해 quote 를 추가하도록 hibernate 설정을 변경한다.
`hibernate.globally_quoted_identifiers=true`

그렇지만 Column 명을 예약어로 사용하는 것보다 그냥 다른 것으로 수정하는 것이 나아보여 우선 "tokenId" 로 변경